### PR TITLE
update: add fallback copy to clipboard

### DIFF
--- a/src/common/hooks/copy.hook.ts
+++ b/src/common/hooks/copy.hook.ts
@@ -10,8 +10,35 @@ export const useCopyToClipboard = (text: string) => {
     [isDark]
   );
 
-  const copy = useCallback(() => {
-    navigator.clipboard.writeText(text.trim());
+  const fallbackCopyTextToClipboard = (text: string) => {
+    const textArea = document.createElement("textarea");
+    textArea.value = text;
+    
+    textArea.style.top = "0";
+    textArea.style.left = "0";
+    textArea.style.position = "fixed";
+  
+    document.body.appendChild(textArea);
+    textArea.focus();
+    textArea.select();
+  
+    try {
+      if (document.execCommand('copy')) {
+        alert("success");
+      }
+    } catch (err) {
+    } finally {
+      document.body.removeChild(textArea);
+    }
+  }
+
+  const copy = useCallback(async () => {
+    if (!navigator.clipboard) {
+      fallbackCopyTextToClipboard(text.trim());
+      return;
+    }
+
+    await navigator.clipboard.writeText(text.trim());
     alert("success");
   }, [text, alert]);
 


### PR DESCRIPTION
This requires a secure origin — either HTTPS or localhost (or disabled by running Chrome with a flag). Just like for ServiceWorker, this state is indicated by the presence or absence of the property on the navigator object.